### PR TITLE
eunit: Include source files in test runfiles for coverage

### DIFF
--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -169,9 +169,21 @@ fi
         content = script,
     )
 
+    # Collect source files from all deps for coverage
+    source_files = []
+    if ctx.configuration.coverage_enabled:
+        # Include source files from the target app
+        source_files.extend(lib_info.srcs)
+        source_files.extend(lib_info.test_srcs)
+        # Include source files from all workspace dependencies
+        for dep in deps:
+            if dep.label.workspace_name == "":
+                source_files.extend(dep[ErlangAppInfo].srcs)
+                source_files.extend(dep[ErlangAppInfo].test_srcs)
+
     runfiles = runfiles.merge_all(
         [ctx.runfiles(
-            files = lib_info.test_data,
+            files = lib_info.test_data + source_files,
             transitive_files = depset(erl_libs_files),
         )] + ([coverdata_to_lcov[DefaultInfo].default_runfiles] if ctx.configuration.coverage_enabled else []) + [
             tool[DefaultInfo].default_runfiles


### PR DESCRIPTION
When coverage is enabled, include source files (srcs and test_srcs) from the target app and all workspace dependencies in the test runfiles. This allows the coverdata_to_lcov tool to find source files in the Bazel sandbox and generate proper LCOV coverage reports.

Without this change, coverdata_to_lcov would fail to locate source files because only compiled .beam files were included in the test runfiles, resulting in empty coverage reports.

Fixes coverage collection for eunit tests.